### PR TITLE
Increases timer of setTimeout

### DIFF
--- a/blocking.html
+++ b/blocking.html
@@ -25,7 +25,7 @@
             setTimeout(function () {
                 sleep(5000);
                 setStatusMessage('Done');
-            }, 0);
+            }, 10);
         }
         function setStatusMessage(msg) {
             document.getElementById('statusMessage').textContent = msg;


### PR DESCRIPTION
In most cases message "Blocking..." doesn't appear, because, I guess, **setTimeout** finishes faster than **document.getElementById** in **setStatusMessage** function and **setTimeout's** callback goes first to the task queue.